### PR TITLE
Remove fallback SVG

### DIFF
--- a/src/assets/lib/mixins/_retina.scss
+++ b/src/assets/lib/mixins/_retina.scss
@@ -25,20 +25,12 @@
 
 // Retina Background with svg support. Modernizr dependent
 $svg-path: '../svg/backgrounds' !default;
-$fallback-path: '../img/svg/fallbacks' !default;
 $fallback-extension: 'png' !default;
 $retina-suffix: '@2x';
 @mixin background-image($name, $size:false){
     background-image: url(#{$svg-path}/#{$name}.svg);
     @if($size){
         background-size: $size;
-    }
-    .no-svg &{
-        background-image: url({#{$fallback-path}/#{$name}.#{$fallback-extension}});
-
-        @media only screen and (-moz-min-device-pixel-ratio: 1.5), only screen and (-o-min-device-pixel-ratio: 3/2), only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-device-pixel-ratio: 1.5) {
-          background-image: url({#{$fallback-path}/#{$name}#{$retina-suffix}.#{$fallback-extension}});
-        }
     }
 }
 


### PR DESCRIPTION
The fallback SVG does not exist in the style guide. However, since we're using mobile and since mobile is cool, I wouldn't imagine any SVG fallback is necessary. If the fallback is necessary, let's get the proper file in place. Otherwise, we should be able to remove this code. What do you think?